### PR TITLE
Improve stability for "unusual" soundings

### DIFF
--- a/src/ecape/calc.py
+++ b/src/ecape/calc.py
@@ -116,7 +116,10 @@ def calc_el_height(
 
     # calculate the el, select the appropriate index & associated height
     el_p, el_t = mpcalc.el(pressure, temperature, dew_point_temperature, parcel_temperature_profile=parcel_profile)
-    el_idx = (pressure - el_p > 0).nonzero()[0][-1]
+    if np.isnan(el_p.m):
+        el_idx = -1
+    else:
+        el_idx = (pressure - el_p > 0).nonzero()[0][-1]
     el_z = height_msl[el_idx]
 
     return el_idx, el_z

--- a/src/ecape/calc.py
+++ b/src/ecape/calc.py
@@ -119,7 +119,7 @@ def calc_el_height(
     # calculate the el, select the appropriate index & associated height
     el_p, el_t = mpcalc.el(pressure, temperature, dew_point_temperature, parcel_temperature_profile=parcel_profile)
     if np.isnan(el_p.m):
-        el_idx = -1
+        el_idx = len(pressure) - 1
     else:
         el_idx = (pressure - el_p > 0).nonzero()[0][-1]
     el_z = height_msl[el_idx]

--- a/src/ecape/calc.py
+++ b/src/ecape/calc.py
@@ -78,6 +78,8 @@ def calc_lfc_height(
 
     # calculate the lfc, select the appropriate index & associated height
     lfc_p, lfc_t = mpcalc.lfc(pressure, temperature, dew_point_temperature, parcel_temperature_profile=parcel_profile)
+    if np.isnan(lfc_p.m):
+        return np.nan, np.nan
     lfc_idx = (pressure - lfc_p > 0).nonzero()[0][-1]
     lfc_z = height_msl[lfc_idx]
 
@@ -372,6 +374,8 @@ def calc_ecape(
 
     # calculate the level of free convection (lfc) and equilibrium level (el) indexes
     lfc_idx, _ = calc_lfc_height(pressure, height_msl, temperature, dew_point_temperature, parcel_func[cape_type])
+    if np.isnan(lfc_idx):
+        return 0 * units("J/kg")
     el_idx, el_z = calc_el_height(pressure, height_msl, temperature, dew_point_temperature, parcel_func[cape_type])
 
     # calculate the buoyancy dilution potential (ncape)


### PR DESCRIPTION
In the case where a sounding does not have a defined equilibrium level (for example a partial sounding due to an early burst), the top of the sounding is generally used as the upper bound for undiluted CAPE integration.

In the case where a sounding does not have an LFC, the CAPE is assumed to be 0 J/kg.

this package currently causes an IndexError in these cases. This PR makes returns the expected values instead.